### PR TITLE
record detail iframe

### DIFF
--- a/oarepo_rdm/initial_config.py
+++ b/oarepo_rdm/initial_config.py
@@ -186,3 +186,4 @@ RDM_RECORDS_ERROR_HANDLERS = {
         )
     ),
 }
+APP_RDM_RECORD_LANDING_PAGE_TEMPLATE = "oarepo_rdm/record_detail_iframe.html"

--- a/oarepo_rdm/templates/semantic-ui/oarepo_rdm/record_detail_iframe.html
+++ b/oarepo_rdm/templates/semantic-ui/oarepo_rdm/record_detail_iframe.html
@@ -1,5 +1,5 @@
 <iframe                                                                                                                                 
-    src="{{ record_ui.links.preview_html }}&embed=true"                                                                                   
+    src="{{ (record_ui.links.preview_html if record_ui.links.preview_html else record_ui.links.self_html) | append_query_params({"embed": "true"}) }}"                                                                                   
     style="width: 100%; min-height: 80vh; border: none;"                                                                                  
     title="{{ _('Record preview') }}"                                                                                                     
-  ></iframe>     
+  ></iframe>

--- a/oarepo_rdm/templates/semantic-ui/oarepo_rdm/record_detail_iframe.html
+++ b/oarepo_rdm/templates/semantic-ui/oarepo_rdm/record_detail_iframe.html
@@ -1,0 +1,5 @@
+<iframe                                                                                                                                 
+    src="{{ record_ui.links.preview_html }}&embed=true"                                                                                   
+    style="width: 100%; min-height: 80vh; border: none;"                                                                                  
+    title="{{ _('Record preview') }}"                                                                                                     
+  ></iframe>     

--- a/oarepo_rdm/ui/templates.py
+++ b/oarepo_rdm/ui/templates.py
@@ -127,3 +127,12 @@ def administration_blueprint(app: Flask) -> Blueprint:  # noqa: ARG001
         template_folder="templates",
         static_folder="static",
     )
+
+
+def oarepo_rdm_blueprint(app: Flask) -> Blueprint:  # noqa: ARG001
+    """Template blueprint for oarepo-rdm own templates."""
+    return Blueprint(
+        "oarepo_rdm_templates",
+        "oarepo_rdm",
+        template_folder="templates",
+    )

--- a/oarepo_rdm/ui/views.py
+++ b/oarepo_rdm/ui/views.py
@@ -11,7 +11,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
-from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from flask import Blueprint, Flask, request
 from invenio_access.permissions import system_identity
@@ -60,6 +59,7 @@ from invenio_records_resources.services.errors import (
     PermissionDeniedError,
     RecordPermissionDeniedError,
 )
+from oarepo_ui.utils import append_query_params
 from sqlalchemy.exc import NoResultFound
 from werkzeug.utils import redirect
 
@@ -163,23 +163,13 @@ def create_records_blueprint(app: Flask) -> Blueprint:
     return blueprint
 
 
-def _append_query_params(url: str, params: dict) -> str:
-    """Append params to a URL, merging with any existing query string."""
-    if not params:
-        return url
-    parsed = urlparse(url)
-    merged = dict(parse_qsl(parsed.query, keep_blank_values=True))
-    merged.update(params)
-    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, urlencode(merged), parsed.fragment))
-
-
 @pass_include_deleted
 def record_detail(pid_value: str, include_deleted: bool = False) -> Response:
     """Redirect to the record detail page."""
     service = cast("RDMRecordService", current_service_registry.get("records"))
     rec = service.read(system_identity, pid_value, include_deleted=include_deleted)
     data = rec.to_dict()
-    self_html = _append_query_params(data["links"]["self_html"], request.args)
+    self_html = append_query_params(data["links"]["self_html"], request.args)
     return redirect(self_html)
 
 
@@ -188,5 +178,5 @@ def deposit_edit(pid_value: str) -> Response:
     service = cast("RDMRecordService", current_service_registry.get("records"))
     draft = service.read_draft(system_identity, pid_value)
     data = draft.to_dict()
-    self_html = _append_query_params(data["links"]["self_html"], request.args)
+    self_html = append_query_params(data["links"]["self_html"], request.args)
     return redirect(self_html)

--- a/oarepo_rdm/ui/views.py
+++ b/oarepo_rdm/ui/views.py
@@ -11,8 +11,9 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
-from flask import Blueprint, Flask
+from flask import Blueprint, Flask, request
 from invenio_access.permissions import system_identity
 from invenio_app_rdm.records_ui.searchapp import search_app_context
 from invenio_app_rdm.records_ui.views.decorators import pass_include_deleted
@@ -162,13 +163,23 @@ def create_records_blueprint(app: Flask) -> Blueprint:
     return blueprint
 
 
+def _append_query_params(url: str, params: dict) -> str:
+    """Append params to a URL, merging with any existing query string."""
+    if not params:
+        return url
+    parsed = urlparse(url)
+    merged = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    merged.update(params)
+    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, urlencode(merged), parsed.fragment))
+
+
 @pass_include_deleted
 def record_detail(pid_value: str, include_deleted: bool = False) -> Response:
     """Redirect to the record detail page."""
     service = cast("RDMRecordService", current_service_registry.get("records"))
     rec = service.read(system_identity, pid_value, include_deleted=include_deleted)
     data = rec.to_dict()
-    self_html = data["links"]["self_html"]
+    self_html = _append_query_params(data["links"]["self_html"], request.args)
     return redirect(self_html)
 
 
@@ -177,5 +188,5 @@ def deposit_edit(pid_value: str) -> Response:
     service = cast("RDMRecordService", current_service_registry.get("records"))
     draft = service.read_draft(system_identity, pid_value)
     data = draft.to_dict()
-    self_html = data["links"]["self_html"]
+    self_html = _append_query_params(data["links"]["self_html"], request.args)
     return redirect(self_html)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ templates_app_rdm_requests = "oarepo_rdm.ui.templates:requests_blueprint"
 templates_app_rdm_communities = "oarepo_rdm.ui.templates:communities_blueprint"
 templates_app_rdm_users = "oarepo_rdm.ui.templates:users_blueprint"
 templates_app_rdm_administration = "oarepo_rdm.ui.templates:administration_blueprint"
+oarepo_rdm_templates = "oarepo_rdm.ui.templates:oarepo_rdm_blueprint"
 # reuse app rdm blueprints
 
 [project.entry-points."invenio_search.mappings"]

--- a/tests/test_ui/test_views.py
+++ b/tests/test_ui/test_views.py
@@ -10,31 +10,9 @@
 
 from __future__ import annotations
 
-from oarepo_rdm.ui.views import _append_query_params
 from tests.models import modela
 
 modela_service = modela.proxies.current_service
-
-
-def test_append_query_params_no_params():
-    assert _append_query_params("https://example.com/record/1", {}) == "https://example.com/record/1"
-
-
-def test_append_query_params_no_existing_query():
-    result = _append_query_params("https://example.com/record/1", {"foo": "bar", "baz": "qux"})
-    assert result == "https://example.com/record/1?foo=bar&baz=qux"
-
-
-def test_append_query_params_merges_with_existing_query():
-    result = _append_query_params("https://example.com/record/1?existing=2", {"incoming": "1"})
-    assert "existing=2" in result
-    assert "incoming=1" in result
-
-
-def test_append_query_params_incoming_overrides_existing():
-    result = _append_query_params("https://example.com/record/1?key=old", {"key": "new"})
-    assert "key=new" in result
-    assert "key=old" not in result
 
 
 def test_record_detail_redirect(app, search_clear, rdm_records_service, users, client):

--- a/tests/test_ui/test_views.py
+++ b/tests/test_ui/test_views.py
@@ -10,9 +10,31 @@
 
 from __future__ import annotations
 
+from oarepo_rdm.ui.views import _append_query_params
 from tests.models import modela
 
 modela_service = modela.proxies.current_service
+
+
+def test_append_query_params_no_params():
+    assert _append_query_params("https://example.com/record/1", {}) == "https://example.com/record/1"
+
+
+def test_append_query_params_no_existing_query():
+    result = _append_query_params("https://example.com/record/1", {"foo": "bar", "baz": "qux"})
+    assert result == "https://example.com/record/1?foo=bar&baz=qux"
+
+
+def test_append_query_params_merges_with_existing_query():
+    result = _append_query_params("https://example.com/record/1?existing=2", {"incoming": "1"})
+    assert "existing=2" in result
+    assert "incoming=1" in result
+
+
+def test_append_query_params_incoming_overrides_existing():
+    result = _append_query_params("https://example.com/record/1?key=old", {"key": "new"})
+    assert "key=new" in result
+    assert "key=old" not in result
 
 
 def test_record_detail_redirect(app, search_clear, rdm_records_service, users, client):
@@ -79,3 +101,34 @@ def test_deposit_edit_not_found(client):
     response = client.get("/uploads/nonexistent-pid-12345")
 
     assert response.status_code == 404
+
+
+def test_record_detail_redirect_preserves_query_params(app, search_clear, rdm_records_service, users, client):
+    """Test that query params are forwarded in the redirect location."""
+    user = users[0]
+    sample_draft = rdm_records_service.create(
+        user.identity,
+        data={"$schema": "local://modela-v1.0.0.json", "files": {"enabled": False}},
+    )
+    published = rdm_records_service.publish(user.identity, sample_draft["id"])
+    pid_value = published["id"]
+    modela_service.indexer.refresh()
+
+    response = client.get(f"/records/{pid_value}?embed=1&theme=dark")
+    assert response.status_code == 302
+    assert "embed=1" in response.location
+    assert "theme=dark" in response.location
+
+
+def test_deposit_edit_redirect_preserves_query_params(app, search_clear, rdm_records_service, users, client):
+    """Test that query params are forwarded in the deposit edit redirect location."""
+    user = users[0]
+    sample_draft = rdm_records_service.create(
+        user.identity,
+        data={"$schema": "local://modela-v1.0.0.json", "files": {"enabled": False}},
+    )
+    pid_value = sample_draft["id"]
+
+    response = client.get(f"/uploads/{pid_value}?embed=1")
+    assert response.status_code == 302
+    assert "embed=1" in response.location


### PR DESCRIPTION
The are using include config.APP_RDM_RECORD_LANDING_PAGE_TEMPLATE in requests template, but this does not work for us and can be replaced by an iframe that is wrapped in this same config variable, so we don't have to overwrite entire templates. This is part of enabling us to use invenio's request detail.

Needs https://github.com/oarepo/oarepo-ui/pull/444