### PR TITLE
fix: removing RDM entrypoints

### DIFF
--- a/oarepo_rdm/__init__.py
+++ b/oarepo_rdm/__init__.py
@@ -10,10 +10,14 @@
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
+
 from .model.presets import rdm_basic_preset, rdm_complete_preset, rdm_minimal_preset
 
-__version__ = "1.1.0dev46"
-"""Version of the library."""
+try:
+    __version__ = version("oarepo-rdm")
+except PackageNotFoundError:
+    __version__ = "0.0.0dev0+unknown"
 
 __all__ = (
     "__version__",

--- a/oarepo_rdm/__init__.py
+++ b/oarepo_rdm/__init__.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from .model.presets import rdm_basic_preset, rdm_complete_preset, rdm_minimal_preset
 
-__version__ = "1.0.0dev46"
+__version__ = "1.1.0dev46"
 """Version of the library."""
 
 __all__ = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oarepo-rdm"
-dynamic = ["version"]
+version = "2.0.0"
 description = ""
 readme = "README.md"
 authors = [
@@ -10,10 +10,13 @@ requires-python = ">=3.14,<3.15"
 
 dependencies = [
     "oarepo[rdm,tests]>=14.0.0,<15.0.0",
-    "oarepo-runtime>=2.0.0dev5,<3.0.0",
-    "oarepo-model>=0.1.0dev17,<1.0.0",
-    "oarepo-ui>=6.0.0dev1",
-    "graphlib"
+    "oarepo-runtime>=3.0.0,<4.0.0",
+    "oarepo-model>=1.0.0,<2.0.0",
+    "oarepo-ui>=8.0.0,<9.0.0",
+
+    # invenio dependencies
+    "invenio-app-rdm>=14.0.0b0,<15.0.0",
+    "invenio-search>=3.0.0,<4.0.0",
 ]
 
 [project.urls]
@@ -26,8 +29,8 @@ dev = [
     "lxml-stubs",
 ]
 tests = [
-    "pytest-invenio",
-    "pytest-oarepo",
+    "pytest-invenio>=4.0.0,<5.0.0",
+    "pytest-oarepo>=3.0.0,<4.0.0",
 ]
 oarepo14 = [
     "oarepo[rdm,tests]>=14.0.0,<15.0.0",
@@ -67,9 +70,6 @@ oarepo_rdm_oai = "oarepo_rdm.oai.mappings"
 
 [project.entry-points."oarepo.cli.search.init"]
 install_percollators = "oarepo_rdm.oai.percolator:init_percolators"
-
-[tool.hatch.version]
-path = "oarepo_rdm/__init__.py"
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,30 +37,15 @@ oarepo14 = [
 oarepo_rdm = "oarepo_rdm.initial_config"
 
 [project.entry-points."invenio_base.apps"]
-invenio_rdm_records = "invenio_rdm_records.ext:InvenioRDMRecords"
 oarepo_rdm = "oarepo_rdm.ext:OARepoRDM"
 
 [project.entry-points."invenio_base.api_apps"]
-invenio_rdm_records = "invenio_rdm_records.ext:InvenioRDMRecords"
 oarepo_rdm = "oarepo_rdm.ext:OARepoRDM"
 
-[project.entry-points."invenio_base.api_blueprints"]
-invenio_rdm_records = "invenio_rdm_records.views:create_records_bp"
-invenio_rdm_records_record_files = "invenio_rdm_records.views:create_record_files_bp"
-invenio_rdm_records_draft_files = "invenio_rdm_records.views:create_draft_files_bp"
-invenio_rdm_records_ext = "invenio_rdm_records.views:blueprint"
-invenio_rdm_records_parent_links = "invenio_rdm_records.views:create_parent_record_links_bp"
-invenio_rdm_records_parent_grants = "invenio_rdm_records.views:create_parent_grants_bp"
-invenio_rdm_records_user_access = "invenio_rdm_records.views:create_grant_user_access_bp"
-invenio_rdm_records_group_access = "invenio_rdm_records.views:create_grant_group_access_bp"
-invenio_rdm_iiif = "invenio_rdm_records.views:create_iiif_bp"
-
 [project.entry-points."invenio_base.finalize_app"]
-invenio_rdm_records = "invenio_rdm_records.ext:finalize_app"
 oarepo_rdm = "oarepo_rdm.ext:finalize_app"
 
 [project.entry-points."invenio_base.api_finalize_app"]
-invenio_rdm_records = "invenio_rdm_records.ext:api_finalize_app"
 oarepo_rdm = "oarepo_rdm.ext:finalize_app"
 
 [project.entry-points."invenio_search.index_templates"]
@@ -76,20 +61,12 @@ templates_app_rdm_communities = "oarepo_rdm.ui.templates:communities_blueprint"
 templates_app_rdm_users = "oarepo_rdm.ui.templates:users_blueprint"
 templates_app_rdm_administration = "oarepo_rdm.ui.templates:administration_blueprint"
 # reuse app rdm blueprints
-invenio_rdm_records_ext = "invenio_rdm_records.views:blueprint"
 
 [project.entry-points."invenio_search.mappings"]
 oarepo_rdm_oai = "oarepo_rdm.oai.mappings"
 
 [project.entry-points."oarepo.cli.search.init"]
 install_percollators = "oarepo_rdm.oai.percolator:init_percolators"
-
-[project.entry-points."invenio_celery.tasks"]
-invenio_rdm_records_fixtures = "invenio_rdm_records.fixtures.tasks"
-invenio_rdm_records_services = "invenio_rdm_records.services.tasks"
-invenio_rdm_records_access_requests = "invenio_rdm_records.requests.access.tasks"
-invenio_rdm_records_iiif = "invenio_rdm_records.services.iiif.tasks"
-invenio_rdm_records_user_moderation = "invenio_rdm_records.requests.user_moderation.tasks"
 
 [tool.hatch.version]
 path = "oarepo_rdm/__init__.py"
@@ -105,4 +82,3 @@ follow_untyped_imports = true
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,12 +148,8 @@ def rdm_model(model_types, finalization_called):
 def app_config(app_config):
     """Mimic an instance's configuration."""
     app_config["JSONSCHEMAS_HOST"] = "localhost"
-    app_config["RECORDS_REFRESOLVER_CLS"] = (
-        "invenio_records.resolver.InvenioRefResolver"
-    )
-    app_config["RECORDS_REFRESOLVER_STORE"] = (
-        "invenio_jsonschemas.proxies.current_refresolver_store"
-    )
+    app_config["RECORDS_REFRESOLVER_CLS"] = "invenio_records.resolver.InvenioRefResolver"
+    app_config["RECORDS_REFRESOLVER_STORE"] = "invenio_jsonschemas.proxies.current_refresolver_store"
     app_config["RATELIMIT_AUTHENTICATED_USER"] = "200 per second"
     app_config["SEARCH_HOSTS"] = [
         {
@@ -175,9 +171,7 @@ def app_config(app_config):
     app_config["RDM_DEFAULT_FILES_ENABLED"] = False
     app_config["RDM_SEARCH_SORT_BY_VERIFIED"] = False
 
-    app_config[
-        "SQLALCHEMY_ENGINE_OPTIONS"
-    ] = {  # avoid pool_timeout set in invenio_app_rdm
+    app_config["SQLALCHEMY_ENGINE_OPTIONS"] = {  # avoid pool_timeout set in invenio_app_rdm
         "pool_pre_ping": False,
         "pool_recycle": 3600,
     }
@@ -215,9 +209,7 @@ def app_config(app_config):
 @pytest.fixture
 def unlifted_expired_embargoed_files_record(rdm_records_service, identity_simple):
     def _record(records_service) -> RDMRecord:
-        with mock.patch(
-            "invenio_rdm_records.services.schemas.access.datetime"
-        ) as mock_dt:
+        with mock.patch("invenio_rdm_records.services.schemas.access.datetime") as mock_dt:
             # invenio validates inside invenio_rdm_records.services.schemas.access.EmbargoSchema that `until` is
             # in the future. Because embargo is evaluated on daily basis we must pretend that actual time is in the
             # past in order for the schema check to pass.
@@ -470,12 +462,8 @@ def input_data():
 def add_file_to_draft():
     """Add a file to the record."""
 
-    def _add_file_to_draft(
-        draft_file_service, draft_id, file_id, identity
-    ) -> dict[str, Any]:
-        result = draft_file_service.init_files(
-            identity, draft_id, data=[{"key": file_id}]
-        )
+    def _add_file_to_draft(draft_file_service, draft_id, file_id, identity) -> dict[str, Any]:
+        result = draft_file_service.init_files(identity, draft_id, data=[{"key": file_id}])
         file_md = next(iter(result.entries))
         assert file_md["key"] == "test.txt"
         assert file_md["status"] == "pending"
@@ -498,9 +486,7 @@ def add_file_to_draft():
 def vocab_fixtures():
     """Create vocabulary types required for VocabulariesOptions.dump()."""
     # contributorsroles
-    current_vocabularies_service.create_type(
-        system_identity, "contributorsroles", "v-ct"
-    )
+    current_vocabularies_service.create_type(system_identity, "contributorsroles", "v-ct")
     current_vocabularies_service.create(
         system_identity,
         {
@@ -555,9 +541,7 @@ def vocab_fixtures():
     )
 
     # descriptiontypes
-    current_vocabularies_service.create_type(
-        system_identity, "descriptiontypes", "dstyp"
-    )
+    current_vocabularies_service.create_type(system_identity, "descriptiontypes", "dstyp")
     current_vocabularies_service.create(
         system_identity,
         {"type": "descriptiontypes", "id": "abstract", "title": {"en": "Abstract"}},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,8 +148,12 @@ def rdm_model(model_types, finalization_called):
 def app_config(app_config):
     """Mimic an instance's configuration."""
     app_config["JSONSCHEMAS_HOST"] = "localhost"
-    app_config["RECORDS_REFRESOLVER_CLS"] = "invenio_records.resolver.InvenioRefResolver"
-    app_config["RECORDS_REFRESOLVER_STORE"] = "invenio_jsonschemas.proxies.current_refresolver_store"
+    app_config["RECORDS_REFRESOLVER_CLS"] = (
+        "invenio_records.resolver.InvenioRefResolver"
+    )
+    app_config["RECORDS_REFRESOLVER_STORE"] = (
+        "invenio_jsonschemas.proxies.current_refresolver_store"
+    )
     app_config["RATELIMIT_AUTHENTICATED_USER"] = "200 per second"
     app_config["SEARCH_HOSTS"] = [
         {
@@ -171,12 +175,12 @@ def app_config(app_config):
     app_config["RDM_DEFAULT_FILES_ENABLED"] = False
     app_config["RDM_SEARCH_SORT_BY_VERIFIED"] = False
 
-    app_config["SQLALCHEMY_ENGINE_OPTIONS"] = (
-        {  # avoid pool_timeout set in invenio_app_rdm
-            "pool_pre_ping": False,
-            "pool_recycle": 3600,
-        },
-    )
+    app_config[
+        "SQLALCHEMY_ENGINE_OPTIONS"
+    ] = {  # avoid pool_timeout set in invenio_app_rdm
+        "pool_pre_ping": False,
+        "pool_recycle": 3600,
+    }
     app_config["REST_CSRF_ENABLED"] = False
 
     app_config["OAISERVER_REPOSITORY_NAME"] = "Some thesis repository."
@@ -211,7 +215,9 @@ def app_config(app_config):
 @pytest.fixture
 def unlifted_expired_embargoed_files_record(rdm_records_service, identity_simple):
     def _record(records_service) -> RDMRecord:
-        with mock.patch("invenio_rdm_records.services.schemas.access.datetime") as mock_dt:
+        with mock.patch(
+            "invenio_rdm_records.services.schemas.access.datetime"
+        ) as mock_dt:
             # invenio validates inside invenio_rdm_records.services.schemas.access.EmbargoSchema that `until` is
             # in the future. Because embargo is evaluated on daily basis we must pretend that actual time is in the
             # past in order for the schema check to pass.
@@ -464,8 +470,12 @@ def input_data():
 def add_file_to_draft():
     """Add a file to the record."""
 
-    def _add_file_to_draft(draft_file_service, draft_id, file_id, identity) -> dict[str, Any]:
-        result = draft_file_service.init_files(identity, draft_id, data=[{"key": file_id}])
+    def _add_file_to_draft(
+        draft_file_service, draft_id, file_id, identity
+    ) -> dict[str, Any]:
+        result = draft_file_service.init_files(
+            identity, draft_id, data=[{"key": file_id}]
+        )
         file_md = next(iter(result.entries))
         assert file_md["key"] == "test.txt"
         assert file_md["status"] == "pending"
@@ -488,7 +498,9 @@ def add_file_to_draft():
 def vocab_fixtures():
     """Create vocabulary types required for VocabulariesOptions.dump()."""
     # contributorsroles
-    current_vocabularies_service.create_type(system_identity, "contributorsroles", "v-ct")
+    current_vocabularies_service.create_type(
+        system_identity, "contributorsroles", "v-ct"
+    )
     current_vocabularies_service.create(
         system_identity,
         {
@@ -543,7 +555,9 @@ def vocab_fixtures():
     )
 
     # descriptiontypes
-    current_vocabularies_service.create_type(system_identity, "descriptiontypes", "dstyp")
+    current_vocabularies_service.create_type(
+        system_identity, "descriptiontypes", "dstyp"
+    )
     current_vocabularies_service.create(
         system_identity,
         {"type": "descriptiontypes", "id": "abstract", "title": {"en": "Abstract"}},


### PR DESCRIPTION
Note: we need to inform people to freeze `oarepo-rdm>=1.0.0dev0,<1.1.0dev0' if they use frozen oarepo