### PR TITLE
Major version bump due to major bump in packages: oarepo-model, oarepo-runtime, pytest-oarepo, oarepo-ui

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oarepo-rdm"
-version = "5.0.0dev0"
+version = "6.0.0"
 description = ""
 readme = "README.md"
 authors = [
@@ -10,9 +10,9 @@ requires-python = ">=3.14,<3.15"
 
 dependencies = [
     "oarepo[rdm,tests]>=14.0.0,<15.0.0",
-    "oarepo-runtime>=4.0.0,<5.0.0",
-    "oarepo-model>=2.0.0,<3.0.0",
-    "oarepo-ui>=10.0.0,<11.0.0",
+    "oarepo-runtime>=5.0.0,<6.0.0",
+    "oarepo-model>=3.0.0,<4.0.0",
+    "oarepo-ui>=11.0.0,<12.0.0",
 
     # invenio dependencies
     "invenio-app-rdm>=14.0.0b0,<15.0.0",
@@ -30,7 +30,7 @@ dev = [
 ]
 tests = [
     "pytest-invenio>=4.0.0,<5.0.0",
-    "pytest-oarepo>=4.0.0,<5.0.0",
+    "pytest-oarepo>=5.0.0,<6.0.0",
 ]
 oarepo14 = [
     "oarepo[rdm,tests]>=14.0.0,<15.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,13 @@ authors = [
 requires-python = ">=3.14,<3.15"
 
 dependencies = [
-    "oarepo[rdm,tests]>=14.0.0,<15.0.0",
+    "oarepo[rdm,tests]>=14.2.1b11.dev1,<15.0.0",
     "oarepo-runtime>=5.0.0,<6.0.0",
     "oarepo-model>=3.0.0,<4.0.0",
     "oarepo-ui>=11.0.0,<12.0.0",
 
     # invenio dependencies
-    "invenio-app-rdm>=14.0.0b0,<15.0.0",
+    "invenio-app-rdm>=14.0.0b0.dev0,<15.0.0",
     "invenio-search>=3.0.0,<4.0.0",
 ]
 


### PR DESCRIPTION
Major version bump due to major bump in packages: oarepo-model, oarepo-runtime, pytest-oarepo, oarepo-ui.

## Included pull requests

- moved rdm related config to oarepo ([#93](https://github.com/oarepo/oarepo-rdm/pull/93))
