### PR TITLE
Remove ChecksComponent from record service components

### DIFF
--- a/oarepo_rdm/model/presets/rdm/services/records/service.py
+++ b/oarepo_rdm/model/presets/rdm/services/records/service.py
@@ -19,8 +19,9 @@ from invenio_drafts_resources.services import RecordService as DraftRecordServic
 from invenio_rdm_records.services.services import RDMRecordService
 
 # TODO: from oarepo_runtime.services.service import SearchAllRecordsService as RDMRecordService
-from oarepo_model.customizations import Customization, ReplaceBaseClass
+from oarepo_model.customizations import Customization, PrependMixin, ReplaceBaseClass
 from oarepo_model.presets import Preset
+from oarepo_runtime.services.config.components import ComponentsOrderingMixin
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -42,3 +43,4 @@ class RDMRecordServicePreset(Preset):
         dependencies: dict[str, Any],
     ) -> Generator[Customization]:
         yield ReplaceBaseClass("RecordService", DraftRecordService, RDMRecordService)
+        yield PrependMixin("RecordService", ComponentsOrderingMixin)

--- a/oarepo_rdm/model/presets/rdm/services/records/service_config.py
+++ b/oarepo_rdm/model/presets/rdm/services/records/service_config.py
@@ -21,14 +21,6 @@ from invenio_drafts_resources.services import (
 from invenio_rdm_records.services.components.files import (
     RDMDraftFilesComponent as InvenioRDMDraftFilesComponent,
 )
-from invenio_rdm_records.services.components.internal_notes import (
-    InternalNotesComponent,
-)
-from invenio_rdm_records.services.components.pids import (
-    ParentPIDsComponent,
-    PIDsComponent,
-)
-from invenio_rdm_records.services.components.verified import ContentModerationComponent
 from invenio_rdm_records.services.config import RDMRecordServiceConfig
 from oarepo_model.customizations import AddToList, Customization, ReplaceBaseClass
 from oarepo_model.presets import Preset
@@ -75,10 +67,6 @@ class RDMRecordServiceConfigPreset(Preset):
     ) -> Generator[Customization]:
         # replace components
         yield AddToList("record_service_components", RDMDraftFilesComponent)
-        yield AddToList("record_service_components", PIDsComponent)
-        yield AddToList("record_service_components", ParentPIDsComponent)
-        yield AddToList("record_service_components", ContentModerationComponent)
-        yield AddToList("record_service_components", InternalNotesComponent)
         yield ReplaceBaseClass(
             "RecordServiceConfig",
             DraftRecordServiceConfig,

--- a/oarepo_rdm/model/presets/rdm/services/records/service_config.py
+++ b/oarepo_rdm/model/presets/rdm/services/records/service_config.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, override
 
-from invenio_checks.components import ChecksComponent
 from invenio_drafts_resources.services import (
     RecordServiceConfig as DraftRecordServiceConfig,
 )
@@ -80,7 +79,6 @@ class RDMRecordServiceConfigPreset(Preset):
         yield AddToList("record_service_components", ParentPIDsComponent)
         yield AddToList("record_service_components", ContentModerationComponent)
         yield AddToList("record_service_components", InternalNotesComponent)
-        yield AddToList("record_service_components", ChecksComponent)
         yield ReplaceBaseClass(
             "RecordServiceConfig",
             DraftRecordServiceConfig,


### PR DESCRIPTION
Fix: removing duplicate components from records inherited from rdm