### PR TITLE
Major version bump due to major bump in packages: invenio-rdm-records, invenio-communities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oarepo-rdm"
-version = "6.0.0"
+version = "7.0.0"
 description = ""
 readme = "README.md"
 authors = [
@@ -10,9 +10,9 @@ requires-python = ">=3.14,<3.15"
 
 dependencies = [
     "oarepo[rdm,tests]>=14.2.1b11.dev1,<15.0.0",
-    "oarepo-runtime>=5.0.0,<6.0.0",
-    "oarepo-model>=3.0.0,<4.0.0",
-    "oarepo-ui>=11.0.0,<12.0.0",
+    "oarepo-runtime>=6.0.0,<7.0.0",
+    "oarepo-model>=4.0.0,<5.0.0",
+    "oarepo-ui>=12.0.0,<13.0.0",
 
     # invenio dependencies
     "invenio-app-rdm>=14.0.0b0.dev0,<15.0.0",
@@ -30,7 +30,7 @@ dev = [
 ]
 tests = [
     "pytest-invenio>=4.0.0,<5.0.0",
-    "pytest-oarepo>=5.0.0,<6.0.0",
+    "pytest-oarepo>=6.0.0,<7.0.0",
 ]
 oarepo14 = [
     "oarepo[rdm,tests]>=14.0.0,<15.0.0",


### PR DESCRIPTION
Major version bump due to major bump in packages: pytest-oarepo, oarepo-runtime, oarepo-model, oarepo-ui.
