### PR TITLE
passing rdm models facets to appropriate config variables

### DIFF
--- a/oarepo_rdm/ext.py
+++ b/oarepo_rdm/ext.py
@@ -73,7 +73,7 @@ class OARepoRDM:
         return MultiplexedSearchOptions("search_all")
 
 
-def finalize_app(_app: Flask) -> None:
+def finalize_app(app: Flask) -> None:
     """Finalize app."""
     from invenio_rdm_records.records.api import RDMDraft as InvenioRDMDraft
     from invenio_rdm_records.records.api import RDMRecord as InvenioRDMRecord
@@ -94,3 +94,39 @@ def finalize_app(_app: Flask) -> None:
         "never-used-for-indexing-drafts-search-alias-used-instead",
         search_alias=[*current_runtime.draft_indices],
     )
+
+    _populate_facet_configs(app)
+
+
+def _populate_facet_configs(app: Flask) -> None:
+    """Derive RDM_FACETS and per-view facet lists from per-model search options.
+
+    The multiplexed search options already merge facets across all registered
+    models for each view (published / drafts / versions). Here we project that
+    merged state onto the Flask config keys read by the FE search apps so the
+    UI selections cannot drift from the backend aggregations.
+    """
+    ext: OARepoRDM = app.extensions["oarepo-rdm"]
+
+    published = dict(ext.search_options.facets)
+    drafts = dict(ext.draft_search_options.facets)
+    # versions = dict(ext.versions_search_options.facets)
+
+    # Build RDM_FACETS pool from per-model search options. FE expects the
+    # `{"facet": TermsFacet, "ui": {...}}` wrapper shape; per-model search
+    # options expose the raw TermsFacet, so wrap with a default `ui.field`.
+    app.config["RDM_FACETS"] = {
+        name: {"facet": facet, "ui": {"field": name}} for name, facet in {**drafts, **published}.items()
+    }
+
+    # FE search apps read `<CONFIG>["facets"]` as the *selected* names to render.
+    # Backend services already aggregate exactly those, via the same merge.
+    _set_facets(app.config, "RDM_SEARCH", published)
+    _set_facets(app.config, "RDM_SEARCH_DRAFTS", drafts)
+    # _set_facets(app.config, "RDM_SEARCH_VERSIONING", versions)
+    # Community records reuse the published search backend.
+    _set_facets(app.config, "COMMUNITIES_RECORDS_SEARCH", published)
+
+
+def _set_facets(config: dict, key: str, facets: dict) -> None:
+    config[key] = {**config.get(key, {}), "facets": list(facets.keys())}

--- a/oarepo_rdm/initial_config.py
+++ b/oarepo_rdm/initial_config.py
@@ -30,6 +30,12 @@ RDM_RECORDS_RESOURCE_CONFIG_CLASS = "oarepo_rdm.resources.records.config:OARepoR
 RDM_RECORDS_RESOURCE_CLASS = "oarepo_rdm.resources.records.resource:OARepoRDMRecordResource"
 """Replacement for the plain RDM resource class."""
 
+RDM_RECORDS_COMMUNITY_RECORDS_CONFIG_CLASS = "oarepo_rdm.services.config:OARepoCommunityRecordsConfig"
+"""Community records service config that uses the multiplexed search options."""
+
+RDM_RECORDS_COMMUNITY_RECORDS_SERVICE_CLASS = "oarepo_rdm.services.service:OARepoCommunityRecordsService"
+"""Community records service that multiplexes search across per-model services."""
+
 RDM_RECORDS_REVIEW_SERVICE_CLASS = "oarepo_rdm.services.delegating.DelegatingReviewService"
 RDM_RECORDS_ACCESS_SERVICE_CLASS = "oarepo_rdm.services.delegating.DelegatingRecordAccessService"
 RDM_RECORDS_PIDS_SERVICE_CLASS = "oarepo_rdm.services.delegating.DelegatingPIDsService"

--- a/oarepo_rdm/services/config.py
+++ b/oarepo_rdm/services/config.py
@@ -17,7 +17,10 @@ from invenio_drafts_resources.services.records.config import (
     SearchOptions,
     is_record,
 )
-from invenio_rdm_records.services.config import RDMRecordServiceConfig
+from invenio_rdm_records.services.config import (
+    RDMCommunityRecordsConfig,
+    RDMRecordServiceConfig,
+)
 from invenio_records_resources.services.base.links import (
     ConditionalLink,
     LinksTemplate,
@@ -158,3 +161,33 @@ class OARepoRDMServiceConfig(RDMRecordServiceConfig):
     @search_all.setter
     def search_all(self, _value: Any) -> None:
         raise AttributeError("search_all is read-only")  # pragma: no cover
+
+
+class OARepoCommunityRecordsConfig(RDMCommunityRecordsConfig):
+    """Community records config that uses multiplexed search options.
+
+    Replaces the stock FromConfigSearchOptions descriptors with the shared
+    multiplexer instances, so /api/communities/<id>/records goes through the
+    same per-model fan-out as /api/records.
+    """
+
+    result_list_cls = MultiplexingResultList
+    schema = MultiplexingSchema  # type: ignore[assignment]
+
+    @property
+    @override
+    def search(self) -> SearchOptions:  # type: ignore[override]
+        return current_oarepo_rdm.search_options
+
+    @search.setter
+    def search(self, _value: Any) -> None:  # type: ignore[override]
+        raise AttributeError("search is read-only")  # pragma: no cover
+
+    @property
+    @override
+    def search_versions(self) -> SearchOptions:  # type: ignore[override]
+        return current_oarepo_rdm.versions_search_options
+
+    @search_versions.setter
+    def search_versions(self, _value: Any) -> None:  # type: ignore[override]
+        raise AttributeError("search_versions is read-only")  # pragma: no cover

--- a/oarepo_rdm/services/service.py
+++ b/oarepo_rdm/services/service.py
@@ -15,6 +15,9 @@ from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, override
 
 from flask import current_app
 from invenio_db.uow import UnitOfWork, unit_of_work
+from invenio_rdm_records.services.community_records.service import (
+    CommunityRecordsService,
+)
 from invenio_rdm_records.services.services import RDMRecordService
 from invenio_records_resources.services import Service as InvenioService
 from oarepo_runtime.proxies import current_runtime
@@ -197,6 +200,72 @@ class DelegationToSpecializedServiceMixin(InvenioService):
             )
         return super().permission_policy(action_name, **kwargs)
 
+    @override
+    def _search(  # pyright: ignore[reportGeneralTypeIssues]
+        self,
+        action: str,
+        identity: Identity,
+        params: dict[str, Any],
+        search_preference: str | None,
+        record_cls: type[RecordItem] | None = None,
+        search_opts: Any | None = None,
+        extra_filter: Any | None = None,
+        permission_action: str = "read",
+        versioning: bool = True,
+        **kwargs: Any,
+    ) -> RecordsSearchV2:
+        """Create the search engine DSL by combining per-model queries."""
+        params.update(kwargs)
+        services = self._search_eligible_services(
+            identity,
+            permissions_search_mapping.get(permission_action, permission_action),
+            **kwargs,
+        )
+        if not services:
+            raise Forbidden
+
+        queries_list: dict[str, dict] = {}
+
+        for jsonschema, service in services.items():
+            search = service._search(  # noqa: SLF001 # calling the same method on delegated
+                action=action,
+                identity=identity,
+                params=copy.deepcopy(params),
+                search_preference=search_preference,
+                record_cls=record_cls,
+                search_opts=search_opts,
+                extra_filter=extra_filter,
+                permission_action=permission_action,
+                versioning=versioning,
+                **kwargs,
+            )
+            queries_list[jsonschema] = search.to_dict()
+
+        params["delegated_query"] = [queries_list, search_opts or self.config.search]
+
+        return super()._search(  # pyright: ignore[reportAttributeAccessIssue]
+            action=action,
+            identity=identity,
+            params=params,
+            search_preference=search_preference,
+            record_cls=record_cls,
+            search_opts=search_opts,
+            extra_filter=extra_filter,
+            permission_action=permission_action,
+            versioning=versioning,
+            **kwargs,
+        )
+
+    def _search_eligible_services(
+        self, identity: Identity, permission_action: str, **kwargs: Any
+    ) -> dict[str, RDMRecordService]:
+        """Get a list of eligible RDM record services."""
+        return {
+            model.record_json_schema: cast("RDMRecordService", model.service)
+            for model in current_runtime.rdm_models
+            if model.service.check_permission(identity, permission_action, **kwargs)
+        }
+
 
 # TODO: won't work for indexer and ParentRecordCommitOp called directly on the global service or with it passed
 # as an argument
@@ -264,73 +333,6 @@ class OARepoRDMService(DelegationToSpecializedServiceMixin, RDMRecordService):
         if schema in current_runtime.rdm_models_by_schema:
             return current_runtime.rdm_models_by_schema[schema]
         raise UndefinedModelError(f"Model for schema {schema} does not exist.")
-
-    @override
-    def _search(
-        self,
-        action: str,
-        identity: Identity,
-        params: dict[str, Any],
-        search_preference: str | None,
-        record_cls: type[RecordItem] | None = None,
-        search_opts: Any | None = None,
-        extra_filter: Any | None = None,
-        permission_action: str = "read",
-        versioning: bool = True,
-        **kwargs: Any,
-    ) -> RecordsSearchV2:
-        """Create the search engine DSL."""
-        params.update(kwargs)
-        # get services that can handle the search request [pid_type -> service]
-        services = self._search_eligible_services(
-            identity,
-            permissions_search_mapping.get(permission_action, permission_action),
-            **kwargs,
-        )
-        if not services:
-            raise Forbidden
-
-        queries_list: dict[str, dict] = {}
-
-        for jsonschema, service in services.items():
-            search = service._search(  # noqa: SLF001 # calling the same method on delegated
-                action=action,
-                identity=identity,
-                params=copy.deepcopy(params),
-                search_preference=search_preference,
-                record_cls=record_cls,
-                search_opts=search_opts,
-                extra_filter=extra_filter,
-                permission_action=permission_action,
-                versioning=versioning,
-                **kwargs,
-            )
-            queries_list[jsonschema] = search.to_dict()
-
-        params["delegated_query"] = [queries_list, search_opts or self.config.search]
-
-        return super()._search(
-            action=action,
-            identity=identity,
-            params=params,
-            search_preference=search_preference,
-            record_cls=record_cls,
-            search_opts=search_opts,
-            extra_filter=extra_filter,
-            permission_action=permission_action,
-            versioning=versioning,
-            **kwargs,
-        )
-
-    def _search_eligible_services(
-        self, identity: Identity, permission_action: str, **kwargs: Any
-    ) -> dict[str, RDMRecordService]:
-        """Get a list of eligible RDM record services."""
-        return {
-            model.record_json_schema: cast("RDMRecordService", model.service)
-            for model in current_runtime.rdm_models
-            if model.service.check_permission(identity, permission_action, **kwargs)
-        }
 
     @override
     def oai_result_item(self, identity: Identity, oai_record_source: dict[str, Any]) -> RecordItem:
@@ -434,3 +436,17 @@ class OARepoRDMService(DelegationToSpecializedServiceMixin, RDMRecordService):
             else:
                 raise NotImplementedError(f"Model {model} does not support relation updates.")  # or pass or to do?
         return True
+
+
+class OARepoCommunityRecordsService(DelegationToSpecializedServiceMixin, CommunityRecordsService):
+    """Community records service that multiplexes search across per-model services.
+
+    Inherits CommunityRecordsService.search (community scope + permission), which
+    calls self._search — the multiplexer-aware override on the mixin assembles
+    per-model queries via DelegatedQueryParam.
+    """
+
+    @property
+    def links_item_tpl(self) -> MultiplexingLinks:
+        """Item links template delegated to the per-model service."""
+        return MultiplexingLinks()

--- a/tests/test_facet_config.py
+++ b/tests/test_facet_config.py
@@ -1,0 +1,135 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-rdm (see https://github.com/oarepo/oarepo-rdm).
+#
+# oarepo-rdm is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+"""Tests for oarepo_rdm.ext._populate_facet_configs.
+
+Exercises the real Flask app — three test models (modela/b/c) are registered
+in tests/models.py, finalize_app runs at app boot, and we assert the resulting
+config keys plus a round-trip filter through rdm_records_service.
+"""
+
+from __future__ import annotations
+
+from invenio_records_resources.services.records.facets import TermsFacet
+
+from .models import modela, modelb, modelc
+
+modela_service = modela.proxies.current_service
+modelb_service = modelb.proxies.current_service
+modelc_service = modelc.proxies.current_service
+
+
+def test_rdm_facets_populated_from_models(app):
+    """RDM_FACETS is the FE-shaped union of every model's facets across views."""
+    rdm_facets = app.config["RDM_FACETS"]
+    assert isinstance(rdm_facets, dict)
+    assert rdm_facets, "RDM_FACETS must be populated"
+
+    # modela explicitly registers a model-specific facet in tests/models.py.
+    assert "metadata_adescription" in rdm_facets
+
+    # Each entry must use the FE wrapper shape expected by invenio_search_ui.
+    for name, entry in rdm_facets.items():
+        assert "facet" in entry, f"{name} missing 'facet' key"
+        assert "ui" in entry, f"{name} missing 'ui' key"
+        assert isinstance(entry["facet"], TermsFacet)
+        assert entry["ui"].get("field") == name
+
+
+def test_per_view_facets_lists_match_merged_options(app):
+    """Each FE search config exposes the merged facet names for its view."""
+    ext = app.extensions["oarepo-rdm"]
+    published = list(ext.search_options.facets.keys())
+    drafts = list(ext.draft_search_options.facets.keys())
+    versions = list(ext.versions_search_options.facets.keys())
+
+    assert app.config["RDM_SEARCH"]["facets"] == published
+    assert app.config["RDM_SEARCH_DRAFTS"]["facets"] == drafts
+    assert app.config["RDM_SEARCH_VERSIONING"]["facets"] == versions
+    # Community records share the published-search backend.
+    assert app.config["COMMUNITIES_RECORDS_SEARCH"]["facets"] == published
+
+
+def test_per_view_lists_are_subset_of_pool(app):
+    """Every per-view selection must exist in the RDM_FACETS pool."""
+    pool = set(app.config["RDM_FACETS"].keys())
+    for cfg_key in (
+        "RDM_SEARCH",
+        "RDM_SEARCH_DRAFTS",
+        "RDM_SEARCH_VERSIONING",
+        "COMMUNITIES_RECORDS_SEARCH",
+    ):
+        missing = set(app.config[cfg_key]["facets"]) - pool
+        assert not missing, f"{cfg_key} lists facets absent from RDM_FACETS: {missing}"
+
+
+def test_model_specific_facet_filters_through_global_service(
+    db, rdm_records_service, identity_simple, vocab_fixtures, required_rdm_metadata, search_clear
+):
+    """Selecting a per-model facet via the multiplexed service narrows the hits."""
+    record_a1 = modela_service.create(
+        identity_simple,
+        {"metadata": {"title": "blah", "adescription": "1"}, "files": {"enabled": False}},
+    )
+    record_a2 = modela_service.create(
+        identity_simple,
+        {"metadata": {"title": "aaaaa", "adescription": "2"}, "files": {"enabled": False}},
+    )
+    record_b1 = modelb_service.create(
+        identity_simple,
+        {
+            "metadata": {**required_rdm_metadata, "title": "kkkkkkkkk", "bdescription": "3"},
+            "files": {"enabled": False},
+        },
+    )
+    rdm_records_service.publish(identity_simple, record_a1["id"])
+    rdm_records_service.publish(identity_simple, record_a2["id"])
+    rdm_records_service.publish(identity_simple, record_b1["id"])
+
+    modela_service.indexer.refresh()
+    modelb_service.indexer.refresh()
+
+    result = rdm_records_service.search(
+        identity_simple,
+        {
+            "q": "",
+            "sort": "bestmatch",
+            "page": 1,
+            "size": 10,
+            "facets": {"metadata_adescription": ["2"]},
+        },
+    )
+    hits = result.to_dict()["hits"]["hits"]
+    assert {h["id"] for h in hits} == {record_a2["id"]}
+
+
+def test_aggregations_include_model_specific_facet(
+    db, rdm_records_service, identity_simple, vocab_fixtures, required_rdm_metadata, search_clear
+):
+    """An unfiltered search returns aggregations for the merged per-model facet."""
+    record_a1 = modela_service.create(
+        identity_simple,
+        {"metadata": {"title": "x", "adescription": "1"}, "files": {"enabled": False}},
+    )
+    record_a2 = modela_service.create(
+        identity_simple,
+        {"metadata": {"title": "y", "adescription": "2"}, "files": {"enabled": False}},
+    )
+    rdm_records_service.publish(identity_simple, record_a1["id"])
+    rdm_records_service.publish(identity_simple, record_a2["id"])
+    modela_service.indexer.refresh()
+
+    result = rdm_records_service.search(
+        identity_simple,
+        {"q": "", "sort": "bestmatch", "page": 1, "size": 10, "facets": {}},
+    )
+    aggs = result.to_dict().get("aggregations", {})
+    assert "metadata_adescription" in aggs, "Multiplexed search must aggregate the per-model facet"
+    buckets = {b["key"]: b["doc_count"] for b in aggs["metadata_adescription"]["buckets"]}
+    assert buckets.get("1") == 1
+    assert buckets.get("2") == 1


### PR DESCRIPTION
1. Passing communities records through a multiplexer as well to be consistent global search, user records search and communities search
2. Passing merged facets to the config of those respective search apps, again to be consistent with per model searches
