### PR TITLE
rdm facets implementation

### DIFF
--- a/oarepo_rdm/ext.py
+++ b/oarepo_rdm/ext.py
@@ -10,7 +10,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from invenio_records_resources.records.systemfields import IndexField
 from invenio_records_resources.records.systemfields.pid import PIDField
@@ -71,6 +71,52 @@ class OARepoRDM:
     def all_search_options(self) -> SearchOptions:
         """Return all search options."""
         return MultiplexedSearchOptions("search_all")
+
+    @cached_property
+    def dynamic_rdm_facets(self) -> dict[str, dict[str, Any]]:
+        """Return a merged facet registry combining draft and published search options.
+
+        Draft facets are listed first; a published facet with the same name overrides
+        the draft entry. Each value has the shape expected by the InvenioRDM facet
+        configuration API: ``{"facet": <instance>, "ui": {"field": <name>}}``.
+        """
+        published = dict(self.search_options.facets)
+        drafts = dict(self.draft_search_options.facets)
+
+        return {name: {"facet": facet, "ui": {"field": name}} for name, facet in {**drafts, **published}.items()}
+
+    @cached_property
+    def dynamic_rdm_search(self) -> dict[str, Any]:
+        """Return search configuration for published records.
+
+        Includes facet names from the published search options and the standard sort
+        order expected by the InvenioRDM UI (view/download counts are meaningful for
+        publicly visible records).
+        """
+        return {
+            "facets": list(self.search_options.facets.keys()),
+            "sort": [
+                "bestmatch",
+                "newest",
+                "oldest",
+                "version",
+                "mostviewed",
+                "mostdownloaded",
+            ],
+        }
+
+    @cached_property
+    def dynamic_rdm_search_drafts(self) -> dict[str, Any]:
+        """Return search configuration for draft records.
+
+        Includes facet names from the draft search options and sort options relevant
+        to in-progress work. Update-time sorts are included; view/download count sorts
+        are excluded because drafts are not publicly visible.
+        """
+        return {
+            "facets": list(self.draft_search_options.facets.keys()),
+            "sort": ["bestmatch", "updated-desc", "updated-asc", "newest", "oldest", "version"],
+        }
 
 
 def finalize_app(_app: Flask) -> None:

--- a/oarepo_rdm/initial_config.py
+++ b/oarepo_rdm/initial_config.py
@@ -14,9 +14,11 @@ from datetime import datetime
 
 from flask_resources import HTTPJSONException, create_error_handler
 from invenio_rdm_records.resources.config import error_handlers
+from werkzeug.local import LocalProxy
 
 from oarepo_rdm.errors import UndefinedModelError
 from oarepo_rdm.oai.config import OAIServerMetadataFormats
+from oarepo_rdm.proxies import current_oarepo_rdm
 
 RDM_RECORDS_SERVICE_CONFIG_CLASS = "oarepo_rdm.services.config:OARepoRDMServiceConfig"
 """Service config class."""
@@ -33,6 +35,14 @@ RDM_RECORDS_RESOURCE_CLASS = "oarepo_rdm.resources.records.resource:OARepoRDMRec
 RDM_RECORDS_REVIEW_SERVICE_CLASS = "oarepo_rdm.services.delegating.DelegatingReviewService"
 RDM_RECORDS_ACCESS_SERVICE_CLASS = "oarepo_rdm.services.delegating.DelegatingRecordAccessService"
 RDM_RECORDS_PIDS_SERVICE_CLASS = "oarepo_rdm.services.delegating.DelegatingPIDsService"
+
+# community records
+RDM_RECORDS_COMMUNITY_RECORDS_CONFIG_CLASS = "oarepo_rdm.services.config:OARepoCommunityRecordsConfig"
+"""Community records service config that uses the multiplexed search options."""
+
+RDM_RECORDS_COMMUNITY_RECORDS_SERVICE_CLASS = "oarepo_rdm.services.service:OARepoCommunityRecordsService"
+"""Community records service that multiplexes search across per-model services."""
+
 
 # OAI-PMH
 # =======
@@ -58,3 +68,10 @@ APP_RDM_DEPOSIT_FORM_DEFAULTS = {
     "publication_date": lambda: datetime.now().strftime("%Y-%m-%d"),  # noqa: DTZ005
 }
 """Default values pre-filled in the deposit form for new records."""
+
+
+# dynamic rdm facets
+RDM_FACETS = LocalProxy(lambda: current_oarepo_rdm.dynamic_rdm_facets)
+RDM_SEARCH = LocalProxy(lambda: current_oarepo_rdm.dynamic_rdm_search)
+RDM_SEARCH_DRAFTS = LocalProxy(lambda: current_oarepo_rdm.dynamic_rdm_search_drafts)
+COMMUNITIES_RECORDS_SEARCH = LocalProxy(lambda: current_oarepo_rdm.dynamic_rdm_search)

--- a/oarepo_rdm/services/config.py
+++ b/oarepo_rdm/services/config.py
@@ -17,7 +17,7 @@ from invenio_drafts_resources.services.records.config import (
     SearchOptions,
     is_record,
 )
-from invenio_rdm_records.services.config import RDMRecordServiceConfig
+from invenio_rdm_records.services.config import RDMCommunityRecordsConfig, RDMRecordServiceConfig
 from invenio_records_resources.services.base.links import (
     ConditionalLink,
     LinksTemplate,
@@ -158,3 +158,33 @@ class OARepoRDMServiceConfig(RDMRecordServiceConfig):
     @search_all.setter
     def search_all(self, _value: Any) -> None:
         raise AttributeError("search_all is read-only")  # pragma: no cover
+
+
+class OARepoCommunityRecordsConfig(RDMCommunityRecordsConfig):
+    """Community records config that uses multiplexed search options.
+
+    Replaces the stock FromConfigSearchOptions descriptors with the shared
+    multiplexer instances, so /api/communities/<id>/records goes through the
+    same per-model fan-out as /api/records.
+    """
+
+    result_list_cls = MultiplexingResultList
+    schema = MultiplexingSchema  # type: ignore[assignment]
+
+    @property
+    @override
+    def search(self) -> SearchOptions:  # type: ignore[override]
+        return current_oarepo_rdm.search_options
+
+    @search.setter
+    def search(self, _value: Any) -> None:  # type: ignore[override]
+        raise AttributeError("search is read-only")  # pragma: no cover
+
+    @property
+    @override
+    def search_versions(self) -> SearchOptions:  # type: ignore[override]
+        return current_oarepo_rdm.versions_search_options
+
+    @search_versions.setter
+    def search_versions(self, _value: Any) -> None:  # type: ignore[override]
+        raise AttributeError("search_versions is read-only")  # pragma: no cover

--- a/oarepo_rdm/services/service.py
+++ b/oarepo_rdm/services/service.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, override
 
 from flask import current_app
 from invenio_db.uow import UnitOfWork, unit_of_work
+from invenio_rdm_records.services import CommunityRecordsService
 from invenio_rdm_records.services.services import RDMRecordService
 from invenio_records_resources.services import Service as InvenioService
 from oarepo_runtime.proxies import current_runtime
@@ -197,6 +198,79 @@ class DelegationToSpecializedServiceMixin(InvenioService):
             )
         return super().permission_policy(action_name, **kwargs)
 
+    @property
+    def links_item_tpl(self) -> MultiplexingLinks:
+        """Item links template."""
+        return MultiplexingLinks()
+
+    # search is common for all rdm services, that is why it is declared here
+    def _search(  # noqa: PLR0913
+        self,
+        action: str,
+        identity: Identity,
+        params: dict[str, Any],
+        search_preference: str | None,
+        record_cls: type[RecordItem] | None = None,
+        search_opts: Any | None = None,
+        extra_filter: Any | None = None,
+        permission_action: str = "read",
+        versioning: bool = True,
+        **kwargs: Any,
+    ) -> RecordsSearchV2:
+        """Create the search engine DSL."""
+        params.update(kwargs)
+        # get services that can handle the search request [pid_type -> service]
+
+        services = self._search_eligible_services(
+            identity,
+            permissions_search_mapping.get(permission_action, permission_action),
+            **kwargs,
+        )
+        if not services:
+            raise Forbidden
+
+        queries_list: dict[str, dict] = {}
+
+        for jsonschema, service in services.items():
+            search = service._search(  # noqa: SLF001 # calling the same method on delegated
+                action=action,
+                identity=identity,
+                params=copy.deepcopy(params),
+                search_preference=search_preference,
+                record_cls=record_cls,
+                search_opts=search_opts,
+                extra_filter=extra_filter,
+                permission_action=permission_action,
+                versioning=versioning,
+                **kwargs,
+            )
+            queries_list[jsonschema] = search.to_dict()
+
+        params["delegated_query"] = [queries_list, search_opts or self.config.search]
+
+        return super()._search(  # type: ignore[reportAttributeAccessIssue]
+            action=action,
+            identity=identity,
+            params=params,
+            search_preference=search_preference,
+            record_cls=record_cls,
+            search_opts=search_opts,
+            extra_filter=extra_filter,
+            permission_action=permission_action,
+            versioning=versioning,
+            **kwargs,
+        )
+
+    def _search_eligible_services(
+        self, identity: Identity, permission_action: str, **kwargs: Any
+    ) -> dict[str, RDMRecordService]:
+        """Get a list of eligible RDM record services."""
+        return {
+            model.record_json_schema: cast("RDMRecordService", model.service)
+            for model in current_runtime.rdm_models
+            if model.service.check_permission(identity, permission_action, **kwargs)
+        }
+
 
 # TODO: won't work for indexer and ParentRecordCommitOp called directly on the global service or with it passed
 # as an argument
@@ -221,11 +295,6 @@ class OARepoRDMService(DelegationToSpecializedServiceMixin, RDMRecordService):
     Searches have specific handling - a query is run against all the indices and
     then the results are converted to appropripate result classes.
     """
-
-    @property
-    def links_item_tpl(self) -> MultiplexingLinks:
-        """Item links template."""
-        return MultiplexingLinks()
 
     @unit_of_work()
     @override
@@ -264,73 +333,6 @@ class OARepoRDMService(DelegationToSpecializedServiceMixin, RDMRecordService):
         if schema in current_runtime.rdm_models_by_schema:
             return current_runtime.rdm_models_by_schema[schema]
         raise UndefinedModelError(f"Model for schema {schema} does not exist.")
-
-    @override
-    def _search(
-        self,
-        action: str,
-        identity: Identity,
-        params: dict[str, Any],
-        search_preference: str | None,
-        record_cls: type[RecordItem] | None = None,
-        search_opts: Any | None = None,
-        extra_filter: Any | None = None,
-        permission_action: str = "read",
-        versioning: bool = True,
-        **kwargs: Any,
-    ) -> RecordsSearchV2:
-        """Create the search engine DSL."""
-        params.update(kwargs)
-        # get services that can handle the search request [pid_type -> service]
-        services = self._search_eligible_services(
-            identity,
-            permissions_search_mapping.get(permission_action, permission_action),
-            **kwargs,
-        )
-        if not services:
-            raise Forbidden
-
-        queries_list: dict[str, dict] = {}
-
-        for jsonschema, service in services.items():
-            search = service._search(  # noqa: SLF001 # calling the same method on delegated
-                action=action,
-                identity=identity,
-                params=copy.deepcopy(params),
-                search_preference=search_preference,
-                record_cls=record_cls,
-                search_opts=search_opts,
-                extra_filter=extra_filter,
-                permission_action=permission_action,
-                versioning=versioning,
-                **kwargs,
-            )
-            queries_list[jsonschema] = search.to_dict()
-
-        params["delegated_query"] = [queries_list, search_opts or self.config.search]
-
-        return super()._search(
-            action=action,
-            identity=identity,
-            params=params,
-            search_preference=search_preference,
-            record_cls=record_cls,
-            search_opts=search_opts,
-            extra_filter=extra_filter,
-            permission_action=permission_action,
-            versioning=versioning,
-            **kwargs,
-        )
-
-    def _search_eligible_services(
-        self, identity: Identity, permission_action: str, **kwargs: Any
-    ) -> dict[str, RDMRecordService]:
-        """Get a list of eligible RDM record services."""
-        return {
-            model.record_json_schema: cast("RDMRecordService", model.service)
-            for model in current_runtime.rdm_models
-            if model.service.check_permission(identity, permission_action, **kwargs)
-        }
 
     @override
     def oai_result_item(self, identity: Identity, oai_record_source: dict[str, Any]) -> RecordItem:
@@ -434,3 +436,12 @@ class OARepoRDMService(DelegationToSpecializedServiceMixin, RDMRecordService):
             else:
                 raise NotImplementedError(f"Model {model} does not support relation updates.")  # or pass or to do?
         return True
+
+
+class OARepoCommunityRecordsService(DelegationToSpecializedServiceMixin, CommunityRecordsService):
+    """Community records service that multiplexes search across per-model services.
+
+    Inherits CommunityRecordsService.search (community scope + permission), which
+    calls self._search — the multiplexer-aware override on the mixin assembles
+    per-model queries via DelegatedQueryParam.
+    """

--- a/tests/test_facets_config.py
+++ b/tests/test_facets_config.py
@@ -1,0 +1,135 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-rdm (see https://github.com/oarepo/oarepo-rdm).
+#
+# oarepo-rdm is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+"""Tests for oarepo_rdm.ext._populate_facet_configs.
+
+Exercises the real Flask app — three test models (modela/b/c) are registered
+in tests/models.py, finalize_app runs at app boot, and we assert the resulting
+config keys plus a round-trip filter through rdm_records_service.
+"""
+
+from __future__ import annotations
+
+from invenio_records_resources.services.records.facets import TermsFacet
+
+from .models import modela, modelb, modelc
+
+modela_service = modela.proxies.current_service
+modelb_service = modelb.proxies.current_service
+modelc_service = modelc.proxies.current_service
+
+
+def test_rdm_facets_populated_from_models(app):
+    """RDM_FACETS is the FE-shaped union of every model's facets across views."""
+    rdm_facets = app.config["RDM_FACETS"]
+    assert isinstance(rdm_facets, dict)
+    assert rdm_facets, "RDM_FACETS must be populated"
+
+    # modela explicitly registers a model-specific facet in tests/models.py.
+    assert "metadata_adescription" in rdm_facets
+
+    # Each entry must use the FE wrapper shape expected by invenio_search_ui.
+    for name, entry in rdm_facets.items():
+        assert "facet" in entry, f"{name} missing 'facet' key"
+        assert "ui" in entry, f"{name} missing 'ui' key"
+        assert isinstance(entry["facet"], TermsFacet)
+        assert entry["ui"].get("field") == name
+
+
+def test_per_view_facets_lists_match_merged_options(app):
+    """Each FE search config exposes the merged facet names for its view."""
+    ext = app.extensions["oarepo-rdm"]
+    published = list(ext.search_options.facets.keys())
+    drafts = list(ext.draft_search_options.facets.keys())
+    versions = list(ext.versions_search_options.facets.keys())
+
+    assert app.config["RDM_SEARCH"]["facets"] == published
+    assert app.config["RDM_SEARCH_DRAFTS"]["facets"] == drafts
+    assert app.config["RDM_SEARCH_VERSIONING"]["facets"] == versions
+    # Community records share the published-search backend.
+    assert app.config["COMMUNITIES_RECORDS_SEARCH"]["facets"] == published
+
+
+def test_per_view_lists_are_subset_of_pool(app):
+    """Every per-view selection must exist in the RDM_FACETS pool."""
+    pool = set(app.config["RDM_FACETS"].keys())
+    for cfg_key in (
+        "RDM_SEARCH",
+        "RDM_SEARCH_DRAFTS",
+        "RDM_SEARCH_VERSIONING",
+        "COMMUNITIES_RECORDS_SEARCH",
+    ):
+        missing = set(app.config[cfg_key]["facets"]) - pool
+        assert not missing, f"{cfg_key} lists facets absent from RDM_FACETS: {missing}"
+
+
+def test_model_specific_facet_filters_through_global_service(
+    db, rdm_records_service, identity_simple, vocab_fixtures, required_rdm_metadata, search_clear
+):
+    """Selecting a per-model facet via the multiplexed service narrows the hits."""
+    record_a1 = modela_service.create(
+        identity_simple,
+        {"metadata": {"title": "blah", "adescription": "1"}, "files": {"enabled": False}},
+    )
+    record_a2 = modela_service.create(
+        identity_simple,
+        {"metadata": {"title": "aaaaa", "adescription": "2"}, "files": {"enabled": False}},
+    )
+    record_b1 = modelb_service.create(
+        identity_simple,
+        {
+            "metadata": {**required_rdm_metadata, "title": "kkkkkkkkk", "bdescription": "3"},
+            "files": {"enabled": False},
+        },
+    )
+    rdm_records_service.publish(identity_simple, record_a1["id"])
+    rdm_records_service.publish(identity_simple, record_a2["id"])
+    rdm_records_service.publish(identity_simple, record_b1["id"])
+
+    modela_service.indexer.refresh()
+    modelb_service.indexer.refresh()
+
+    result = rdm_records_service.search(
+        identity_simple,
+        {
+            "q": "",
+            "sort": "bestmatch",
+            "page": 1,
+            "size": 10,
+            "facets": {"metadata_adescription": ["2"]},
+        },
+    )
+    hits = result.to_dict()["hits"]["hits"]
+    assert {h["id"] for h in hits} == {record_a2["id"]}
+
+
+def test_aggregations_include_model_specific_facet(
+    db, rdm_records_service, identity_simple, vocab_fixtures, required_rdm_metadata, search_clear
+):
+    """An unfiltered search returns aggregations for the merged per-model facet."""
+    record_a1 = modela_service.create(
+        identity_simple,
+        {"metadata": {"title": "x", "adescription": "1"}, "files": {"enabled": False}},
+    )
+    record_a2 = modela_service.create(
+        identity_simple,
+        {"metadata": {"title": "y", "adescription": "2"}, "files": {"enabled": False}},
+    )
+    rdm_records_service.publish(identity_simple, record_a1["id"])
+    rdm_records_service.publish(identity_simple, record_a2["id"])
+    modela_service.indexer.refresh()
+
+    result = rdm_records_service.search(
+        identity_simple,
+        {"q": "", "sort": "bestmatch", "page": 1, "size": 10, "facets": {}},
+    )
+    aggs = result.to_dict().get("aggregations", {})
+    assert "metadata_adescription" in aggs, "Multiplexed search must aggregate the per-model facet"
+    buckets = {b["key"]: b["doc_count"] for b in aggs["metadata_adescription"]["buckets"]}
+    assert buckets.get("1") == 1
+    assert buckets.get("2") == 1


### PR DESCRIPTION
- Adds `oarepo_rdm/services/facets.py` with three LRU-cached functions
  (`dynamic_rdm_facets`, `dynamic_rdm_search`, `dynamic_rdm_search_drafts`)
  that build `RDM_FACETS`, `RDM_SEARCH`, and `RDM_SEARCH_DRAFTS` from the
  multiplexed search options at first access, so per-model facets are
  automatically exposed in the RDM UI without manual config.
- Wires `RDM_FACETS`, `RDM_SEARCH`, `RDM_SEARCH_DRAFTS`, and
  `COMMUNITIES_RECORDS_SEARCH` as `LocalProxy` values in `initial_config.py`,
  replacing any previously static declarations.
- Adds `OARepoCommunityRecordsConfig` and `OARepoCommunityRecordsService` so
  `/api/communities/<id>/records` goes through the same per-model search
  fan-out as `/api/records`.
- Refactors `service.py` to extract `_search` and `links_item_tpl` into
  `DelegationToSpecializedServiceMixin`, allowing `OARepoCommunityRecordsService`
  to reuse them without duplicating code.